### PR TITLE
Overwrite existing relation when changing permission level.

### DIFF
--- a/app/models/concerns/caber/object.rb
+++ b/app/models/concerns/caber/object.rb
@@ -18,7 +18,9 @@ module Caber::Object
   end
 
   def grant_permission_to(permission, subject)
-    Caber::Relation.create!(subject: subject, permission: permission, object: self)
+    rel = Caber::Relation.find_or_initialize_by(subject: subject, object: self)
+    rel.permission = permission
+    rel.save!
   end
 
   def grants_permission_to?(permission, subject)

--- a/lib/generators/caber/templates/install/migrations/01_create_caber_relations.rb.erb
+++ b/lib/generators/caber/templates/install/migrations/01_create_caber_relations.rb.erb
@@ -6,6 +6,7 @@ class CreateCaberRelations < ActiveRecord::Migration<%= migration_version %>
       t.references :object, polymorphic: true, null: false
 
       t.timestamps
+      t.index [:subject_id, :subject_type, :object_id, :object_type], unique: true
     end
   end
 end

--- a/spec/dummy/db/migrate/20240828150152_create_caber_relations.rb
+++ b/spec/dummy/db/migrate/20240828150152_create_caber_relations.rb
@@ -6,6 +6,7 @@ class CreateCaberRelations < ActiveRecord::Migration[7.2]
       t.references :object, polymorphic: true, null: false
 
       t.timestamps
+      t.index [:subject_id, :subject_type, :object_id, :object_type], unique: true
     end
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -20,6 +20,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_28_150152) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["object_type", "object_id"], name: "index_caber_relations_on_object"
+    t.index ["subject_id", "subject_type", "object_id", "object_type"], name: "idx_on_subject_id_subject_type_object_id_object_typ_a279b094be", unique: true
     t.index ["subject_type", "subject_id"], name: "index_caber_relations_on_subject"
   end
 

--- a/spec/models/caber/relation_spec.rb
+++ b/spec/models/caber/relation_spec.rb
@@ -139,6 +139,27 @@ RSpec.describe Caber::Relation, :multiuser do
     end
   end
 
+  context "changing permissions" do
+    before do
+      object.grant_permission_to "viewer", alice
+    end
+
+    it "should update the existing permission relation" do
+      expect { object.grant_permission_to("editor", alice) }
+        .not_to change(Caber::Relation, :count)
+    end
+
+    it "should store the new permission" do
+      object.grant_permission_to("editor", alice)
+      expect(alice.has_permission_on?("editor", object)).to be true
+    end
+
+    it "should overwrite the old permission" do
+      object.grant_permission_to("editor", alice)
+      expect(alice.has_permission_on?("viewer", object)).to be false
+    end
+  end
+
   context "removing permissions on object/subject removal" do
     before do
       object.grant_permission_to "viewer", alice


### PR DESCRIPTION
So we don't get duplicates. Also enforced at database level.